### PR TITLE
Alternative fix to panics from empty set operations.

### DIFF
--- a/intervalset/intervalset_immutable.go
+++ b/intervalset/intervalset_immutable.go
@@ -23,7 +23,13 @@ type ImmutableSet struct {
 // NewImmutableSet returns a new set given a sorted slice of intervals. This
 // function panics if the intervals are not sorted.
 func NewImmutableSet(intervals []Interval) *ImmutableSet {
-	return &ImmutableSet{NewSet(intervals)}
+	return NewImmutableSetV1(intervals, oldBehaviorFactory.makeZero)
+}
+
+// NewImmutableSetV1 returns a new set given a sorted slice of intervals. This
+// function panics if the intervals are not sorted.
+func NewImmutableSetV1(intervals []Interval, makeZero func() Interval) *ImmutableSet {
+	return &ImmutableSet{NewSetV1(intervals, makeZero)}
 }
 
 // String returns a human-friendly representation of the set.

--- a/intervalset/intervalset_test.go
+++ b/intervalset/intervalset_test.go
@@ -170,6 +170,28 @@ func TestAdd(t *testing.T) {
 		want []*span
 	}{
 		{
+			"empty + empty = empty",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{}),
+			[]*span{},
+		},
+		{
+			"empty + [30,111) = [30, 111)",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{&span{30, 111}}),
+			[]*span{
+				{30, 111},
+			},
+		},
+		{
+			"[20, 40) + empty = [20, 40)",
+			NewSet([]Interval{&span{20, 40}}),
+			NewImmutableSet([]Interval{}),
+			[]*span{
+				{20, 40},
+			},
+		},
+		{
 			"[20, 40) + [60,111)",
 			NewSet([]Interval{&span{20, 40}}),
 			NewSet([]Interval{&span{60, 111}}),
@@ -205,6 +227,26 @@ func TestSub(t *testing.T) {
 		b    SetInput
 		want []*span
 	}{
+		{
+			"empty - empty = empty",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{}),
+			[]*span{},
+		},
+		{
+			"empty - [30,111) = empty",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{&span{30, 111}}),
+			[]*span{},
+		},
+		{
+			"[20, 40) - empty = [20, 40)",
+			NewSet([]Interval{&span{20, 40}}),
+			NewImmutableSet([]Interval{}),
+			[]*span{
+				{20, 40},
+			},
+		},
 		{
 			"[20, 40) - [30,111)",
 			NewSet([]Interval{&span{20, 40}}),
@@ -261,6 +303,24 @@ func TestIntersect(t *testing.T) {
 		b    SetInput
 		want []*span
 	}{
+		{
+			"empty intersect empty = empty",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{}),
+			[]*span{},
+		},
+		{
+			"empty intersect [30,111) = empty",
+			NewSet([]Interval{}),
+			NewImmutableSet([]Interval{&span{30, 111}}),
+			[]*span{},
+		},
+		{
+			"[20, 40) intersect empty = empty",
+			NewSet([]Interval{&span{20, 40}}),
+			NewImmutableSet([]Interval{}),
+			[]*span{},
+		},
 		{
 			"[20, 40) intersect [30,111)",
 			NewSet([]Interval{&span{20, 40}}),
@@ -329,6 +389,24 @@ func TestContains(t *testing.T) {
 		elem *span
 		want bool
 	}{
+		{
+			name: "{} contains empty interval",
+			set:  NewSet([]Interval{}),
+			elem: &span{},
+			want: true,
+		},
+		{
+			name: "{} does not contain [30,111)",
+			set:  NewSet([]Interval{}),
+			elem: &span{30, 111},
+			want: false,
+		},
+		{
+			name: "[20, 40) contains empty interval",
+			set:  NewSet([]Interval{&span{20, 40}}),
+			elem: &span{},
+			want: true,
+		},
 		{
 			name: "{[0, 5), [10, 15)} contains [0, 5)]",
 			set:  NewSet([]Interval{&span{0, 5}, &span{10, 15}}),

--- a/timespanset/timespanset_test.go
+++ b/timespanset/timespanset_test.go
@@ -134,6 +134,36 @@ func TestIntersect(t *testing.T) {
 		want   []*timespan
 	}{
 		{
+			name: "subtract empty from empty",
+			set: func() *Set {
+				w := Empty()
+				w.Sub(Empty())
+				return w
+			}(),
+			bounds: &timespan{past, future},
+			want:   []*timespan{},
+		},
+		{
+			name: "subtract weeks 1 and 3 from empty",
+			set: func() *Set {
+				w := Empty()
+				w.Sub(weeks1And3())
+				return w
+			}(),
+			bounds: &timespan{past, future},
+			want:   []*timespan{},
+		},
+		{
+			name: "subtract empty from weeks 1 and 3",
+			set: func() *Set {
+				w := weeks1And3()
+				w.Sub(Empty())
+				return w
+			}(),
+			bounds: &timespan{past, future},
+			want:   []*timespan{week1, week3},
+		},
+		{
 			name: "subtract weeks 1 and 3 from weeks123",
 			set: func() *Set {
 				w := weeks123()


### PR DESCRIPTION
The original pull request[1] involves less code but changes the iteration interface to actually support iterating over the nil Interval object. We may want that behavior but for now I decided to check if Extent() is nil in the generic interval logic.

[1] https://github.com/google/go-intervals/pull/3